### PR TITLE
Make sure CLI and FPM have the same custom php config

### DIFF
--- a/vhosting/config.sls
+++ b/vhosting/config.sls
@@ -36,6 +36,17 @@ php_config-{{php_version}}:
       - service: php{{php_version}}-fpm
       {%- else %}
       - service: {{ webserver }}
+      {% endif %}
+
+php_cli_config-{{php_version}}:
+  file.symlink:
+    - name: /etc/php/{{php_version}}/cli/conf.d/zzz_custom.ini
+    - target: /etc/php/{{php_version}}/fpm/conf.d/zzz_custom.ini
+    - watch_in:
+      {%- if webserver == 'nginx' %}
+      - service: php{{php_version}}-fpm
+      {%- else %}
+      - service: {{ webserver }}
       {% endif -%}
 
 {% endfor %} # End 'for php_version in php_versions'


### PR DESCRIPTION
  Specifically on the custom ppa repo versions

Should fix #8.

Another option is to write the `zzz-custom.ini` to the `mods-available` directory just as the distribution does but that would touch the `zzz-custom.ini` files for the fpm sapi in current installations and requires more testing.
What do you think @syphernl?
