### PR TITLE
Rename php5 fpm

### DIFF
--- a/vhosting/webstack/zendserver.sls
+++ b/vhosting/webstack/zendserver.sls
@@ -30,7 +30,7 @@ include:
 {% if php_versions|length > 0 %}
 # The PHP-FPM formula only creates these folders if only the "default" PHP stack
 #  is being used, not if multiple co-exist (in combination with ZS).
-/usr/local/zend/etc/fpm.d:
+/usr/local/zend/etc/php-fpm.d:
   file.directory:
     - require:
       - pkg: zendserver
@@ -42,7 +42,7 @@ include:
     - require:
       - pkg: zendserver
     - require_in:
-      - file: /usr/local/zend/etc/fpm.d
+      - file: /usr/local/zend/etc/php-fpm.d
 {%- endif %}
 {%- endif %}
 
@@ -73,7 +73,7 @@ include:
 #
 #kill_fpm:
 #  service.dead:
-#    - name: php5-fpm
+#    - name: php-fpm
 #{%- endif %}
 
 {%- if not enable_zray %}
@@ -86,6 +86,6 @@ include:
     - watch_in:
       - service: zendserver
 {%- if webserver == 'nginx' %}
-      - service: php5-fpm
+      - service: php-fpm
 {% endif -%}
 {%- endif %}

--- a/vhosting/webstack/zendserver.sls
+++ b/vhosting/webstack/zendserver.sls
@@ -15,18 +15,6 @@ include:
 {%- endif %}
 
 {%- if webserver == 'nginx' and not disable_webserver %}
-## Re-configure PHP-FPM to allow multiple pools to be used
-/usr/local/zend/etc/php-fpm.conf:
-  file.uncomment:
-    - regex: ^include=etc
-    - char: ;
-    - require:
-      - pkg: zendserver
-    - require_in:
-      - service: php5-fpm
-    - watch_in:
-      - service: zendserver
-
 {% if php_versions|length > 0 %}
 # The PHP-FPM formula only creates these folders if only the "default" PHP stack
 #  is being used, not if multiple co-exist (in combination with ZS).

--- a/vhosting/webstack/zendserver.sls
+++ b/vhosting/webstack/zendserver.sls
@@ -18,19 +18,17 @@ include:
 {% if php_versions|length > 0 %}
 # The PHP-FPM formula only creates these folders if only the "default" PHP stack
 #  is being used, not if multiple co-exist (in combination with ZS).
-/usr/local/zend/etc/php-fpm.d:
+/usr/local/zend/etc/fpm.d:
   file.directory:
     - require:
       - pkg: zendserver
-    - require_in:
-      - file: /usr/local/zend/etc/php-fpm.conf
 
 /usr/local/zend/tmp:
   file.directory:
     - require:
       - pkg: zendserver
     - require_in:
-      - file: /usr/local/zend/etc/php-fpm.d
+      - file: /usr/local/zend/etc/fpm.d
 {%- endif %}
 {%- endif %}
 


### PR DESCRIPTION
Along with the [Zend Server](https://github.com/Enrise/zendserver-formula/pull/5) and [PHPFPM](https://github.com/Enrise/phpfpm-formula/pull/20) formula this change drops the php5-fpm naming convention. Next to that it updates the logic to support the latest Zend Server releases.