### PR TITLE
Update zendserver.sls

### DIFF
--- a/vhosting/webstack/zendserver.sls
+++ b/vhosting/webstack/zendserver.sls
@@ -71,7 +71,7 @@ include:
     - onlyif: test -e /usr/local/zend/etc/conf.d/zray.ini
     - watch_in:
       - service: zendserver
-{%- if webserver == 'nginx' %}
-      - service: php-fpm
-{% endif -%}
+{%- for php_version in php_versions %}
+      - service: php{{ php_version }}-fpm
+{%- endfor %}
 {%- endif %}


### PR DESCRIPTION
Het is volstrekt mogelijk dat service php-fpm niet bestaat als webserver==nginx. Dat hangt namelijk af van heel andere logica. Alle php-versions bij langs is logischer en zorgt niet voor fouten.