### PR TITLE
Remove deprecated certbot PPA

### DIFF
--- a/vhosting/letsencrypt.sls
+++ b/vhosting/letsencrypt.sls
@@ -3,7 +3,8 @@
 
 # Install certbot for automatic certificate renewal
 letsencrypt-client:
-  pkgrepo.managed:
+  # this package repo is deprecated see https://launchpad.net/~certbot/+archive/ubuntu/certbot
+  pkgrepo.absent:
     - ppa: certbot/certbot
   pkg.installed:
     - pkgs:


### PR DESCRIPTION
The certbot PPA is deprecated and is included in the native ubuntu / debian repository.
See [here](https://packages.ubuntu.com/search?keywords=certbot&searchon=names&suite=all&section=all) for all versions
and see [here](https://launchpad.net/~certbot/+archive/ubuntu/certbot) for the deprecation warning